### PR TITLE
Change race condition avoidance hashing

### DIFF
--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -233,7 +233,8 @@ Outputs the uploaded files for the given prefix
 }
 
 func pushFile(projectFilepath string, prefix string) {
-	remoteFile := path.Clean(prefix + "/" + projectFilepath)
+	remoteFile := fmt.Sprintf("%s/%s.%s", prefix, projectFilepath, projectFileHash(projectFilepath))
+	remoteFile = path.Clean(remoteFile)
 
 	_, err := client.Upload(projectFilepath, &smartling.UploadRequest{
 		FileUri:      remoteFile,

--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -153,7 +154,7 @@ var projectPullCommand = cli.Command{
 }
 
 func cleanPrefix(s string) string {
-	s = filepath.Clean("/" + s)
+	s = path.Clean("/" + s)
 	if s == "/" {
 		return ""
 	}
@@ -232,7 +233,7 @@ Outputs the uploaded files for the given prefix
 }
 
 func pushFile(projectFilepath string, prefix string) {
-	remoteFile := filepath.Clean(prefix + "/" + projectFilepath)
+	remoteFile := path.Clean(prefix + "/" + projectFilepath)
 
 	_, err := client.Upload(projectFilepath, &smartling.UploadRequest{
 		FileUri:      remoteFile,
@@ -255,7 +256,7 @@ func pushProjectFiles(prefix string) {
 }
 
 func filetypeForProjectFile(projectFilepath string) smartling.FileType {
-	ft := smartling.FileTypeByExtension(filepath.Ext(projectFilepath))
+	ft := smartling.FileTypeByExtension(path.Ext(projectFilepath))
 	if ft == "" {
 		ft = ProjectConfig.FileType
 	}
@@ -276,7 +277,7 @@ type FilenameParts struct {
 }
 
 func localRelativeFilePath(remotepath string) string {
-	fp, err := filepath.Rel(".", filepath.Join(ProjectConfig.path, remotepath))
+	fp, err := filepath.Rel(".", path.Join(ProjectConfig.path, remotepath))
 	logAndQuitIfError(err)
 	return fp
 }
@@ -284,9 +285,9 @@ func localRelativeFilePath(remotepath string) string {
 func localPullFilePath(p, locale string) string {
 	parts := FilenameParts{
 		Path:   p,
-		Dir:    filepath.Dir(p),
-		Base:   filepath.Base(p),
-		Ext:    filepath.Ext(p),
+		Dir:    path.Dir(p),
+		Base:   path.Base(p),
+		Ext:    path.Ext(p),
 		Locale: locale,
 	}
 

--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -143,7 +143,7 @@ func pullProjectFiles() {
 }
 
 func pull(locale, projectFilepath string) {
-	hit, b, err, _ := translateViaCache(
+	hit, b, err, _ := translate(
 		locale,
 		localRelativeFilePath(projectFilepath),
 		filetypeForProjectFile(projectFilepath),

--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -226,9 +226,8 @@ Outputs the uploaded files for the given prefix
 		}
 
 		prefix := prefixOrGitPrefix(c.Args().Get(0))
-		locales := fetchLocales()
 
-		push(prefix, locales)
+		push(prefix)
 	},
 }
 
@@ -254,14 +253,16 @@ func pushFile(projectFilepath string, prefix string, locales []string) {
 	}
 }
 
-func push(prefix string, locales []string) {
+func push(prefix string) {
+	locales := fetchLocales()
+
 	var wg sync.WaitGroup
 	for _, projectFilepath := range ProjectConfig.Files() {
 		wg.Add(1)
-		go func(prefix, projectFilepath string) {
+		go func(projectFilepath string) {
 			defer wg.Done()
 			pushFile(projectFilepath, prefix, locales)
-		}(prefix, projectFilepath)
+		}(projectFilepath)
 	}
 	wg.Wait()
 }

--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -233,7 +233,7 @@ Outputs the uploaded files for the given prefix
 func projectFileRemoteName(projectFilepath, prefix string) string {
 	remoteFile := projectFilepath
 	if prefix != "" {
-		remoteFile = fmt.Sprintf("%s/%s.%s", prefix, projectFilepath, projectFileHash(projectFilepath))
+		remoteFile = fmt.Sprintf("%s/%s/%s", prefix, projectFileHash(projectFilepath), projectFilepath)
 	}
 
 	return path.Clean(remoteFile)

--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -167,10 +167,6 @@ func prefixOrGitPrefix(prefix string) string {
 		prefix = pushPrefix()
 	}
 
-	if prefix == "/branch/master" {
-		prefix = "/"
-	}
-
 	prefix = cleanPrefix(prefix)
 
 	if prefix != "" {
@@ -233,11 +229,14 @@ Outputs the uploaded files for the given prefix
 	},
 }
 
+// if prefix is empty, don't append the hash also
 func projectFileRemoteName(projectFilepath, prefix string) string {
-	remoteFile := fmt.Sprintf("%s/%s.%s", prefix, projectFilepath, projectFileHash(projectFilepath))
-	remoteFile = path.Clean(remoteFile)
+	remoteFile := projectFilepath
+	if prefix != "" {
+		remoteFile = fmt.Sprintf("%s/%s.%s", prefix, projectFilepath, projectFileHash(projectFilepath))
+	}
 
-	return remoteFile
+	return path.Clean(remoteFile)
 }
 
 func pushProjectFile(projectFilepath, prefix string) string {

--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -141,7 +141,7 @@ func pullAllProjectFiles(prefix string) {
 }
 
 func pullProjectFile(projectFilepath, locale, prefix string) {
-	hit, b, err, _ := translateProjectFile(projectFilepath, locale, prefix)
+	hit, b, err := translateProjectFile(projectFilepath, locale, prefix)
 	logAndQuitIfError(err)
 
 	fp := localPullFilePath(projectFilepath, locale)

--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -107,13 +107,13 @@ var projectStatusCommand = cli.Command{
 }
 
 var projectPullCommand = cli.Command{
-	Name:  "pull",
-	Usage: "translate local project files using Smartling as a translation memory",
-
+	Name:        "pull",
+	Usage:       "translate local project files using Smartling as a translation memory",
+	Description: "pull [<prefix>]",
 	Action: func(c *cli.Context) {
 		if len(c.Args()) > 1 {
 			log.Println("Wrong number of arguments")
-			log.Fatalln("Usage: status [<prefix>]")
+			log.Fatalln("Usage: pull [<prefix>]")
 		}
 
 		prefix := prefixOrGitPrefix(c.Args().Get(0))

--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -143,12 +143,7 @@ func pullProjectFiles() {
 }
 
 func pull(locale, projectFilepath string) {
-	hit, b, err, _ := translate(
-		locale,
-		localRelativeFilePath(projectFilepath),
-		filetypeForProjectFile(projectFilepath),
-		ProjectConfig.ParserConfig,
-	)
+	hit, b, err, _ := translateProjectFile(projectFilepath, locale)
 	logAndQuitIfError(err)
 
 	fp := localPullFilePath(projectFilepath, locale)

--- a/cli/smartling/project.go
+++ b/cli/smartling/project.go
@@ -147,9 +147,9 @@ func pullProjectFile(projectFilepath, locale, prefix string) {
 	fp := localPullFilePath(projectFilepath, locale)
 	cached := ""
 	if hit {
-		cached = "(using cache)"
+		cached = "(from cache)"
 	}
-	fmt.Println(fp, cached)
+	fmt.Println("Pulled", fp, cached)
 	err = ioutil.WriteFile(fp, b, 0644)
 	logAndQuitIfError(err)
 }

--- a/cli/smartling/status.go
+++ b/cli/smartling/status.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"sync"
 	"text/tabwriter"
 
@@ -58,9 +57,9 @@ func GetProjectStatus(prefix string, locales []string) ProjectStatus {
 	remoteFiles := fetchRemoteFileList()
 
 	for _, projectFilepath := range ProjectConfig.Files() {
-		prefixedProjectFilepath := filepath.Clean("/" + prefix + "/" + projectFilepath)
-		if !remoteFiles.contains(prefixedProjectFilepath) {
-			prefixedProjectFilepath = filepath.Clean("/" + projectFilepath)
+		remoteFilePath := projectFileRemoteName(projectFilepath, prefix)
+		if !remoteFiles.contains(remoteFilePath) {
+			pushProjectFile(projectFilepath, prefix)
 		}
 
 		for _, l := range locales {
@@ -68,7 +67,7 @@ func GetProjectStatus(prefix string, locales []string) ProjectStatus {
 			go func(remotefile, locale string) {
 				defer wg.Done()
 				statuses.Add(remotefile, locale, MustStatus(remotefile, locale))
-			}(prefixedProjectFilepath, l)
+			}(remoteFilePath, l)
 		}
 	}
 	wg.Wait()

--- a/cli/smartling/status.go
+++ b/cli/smartling/status.go
@@ -54,13 +54,9 @@ func (statuses ProjectStatus) TotalStringsCount() int {
 func GetProjectStatus(prefix string, locales []string) ProjectStatus {
 	var wg sync.WaitGroup
 	statuses := ProjectStatus{}
-	remoteFiles := fetchRemoteFileList()
 
 	for _, projectFilepath := range ProjectConfig.Files() {
-		remoteFilePath := projectFileRemoteName(projectFilepath, prefix)
-		if !remoteFiles.contains(remoteFilePath) {
-			pushProjectFile(projectFilepath, prefix)
-		}
+		remoteFilePath := findIdenticalRemoteFileOrPush(projectFilepath, prefix)
 
 		for _, l := range locales {
 			wg.Add(1)

--- a/cli/smartling/translate.go
+++ b/cli/smartling/translate.go
@@ -59,7 +59,7 @@ func uploadAsTempFile(localpath string, filetype smartling.FileType, parserConfi
 	uploadMutex[localpath].Lock()
 	defer uploadMutex[localpath].Unlock()
 
-	tmppath := "/tmp/" + projectFileHash("", localpath, filetype, parserConfig)
+	tmppath := "/tmp/" + hash("", localpath, filetype, parserConfig)
 	if tempFilesUploaded.contains(tmppath) {
 		return tmppath, nil
 	}
@@ -79,7 +79,16 @@ func uploadAsTempFile(localpath string, filetype smartling.FileType, parserConfi
 	return tmppath, nil
 }
 
-func projectFileHash(locale, localpath string, filetype smartling.FileType, parserConfig map[string]string) string {
+func projectFileHash(projectFilepath string) string {
+	return hash(
+		"",
+		localRelativeFilePath(projectFilepath),
+		filetypeForProjectFile(projectFilepath),
+		ProjectConfig.ParserConfig,
+	)
+}
+
+func hash(locale, localpath string, filetype smartling.FileType, parserConfig map[string]string) string {
 	file, err := os.Open(localpath)
 	logAndQuitIfError(err)
 	defer file.Close()
@@ -97,7 +106,7 @@ func projectFileHash(locale, localpath string, filetype smartling.FileType, pars
 
 func translateViaCache(locale, localpath string, filetype smartling.FileType, parserConfig map[string]string) (hit bool, b []byte, err error, ch string) {
 
-	ch = projectFileHash(locale, localpath, filetype, parserConfig)
+	ch = hash(locale, localpath, filetype, parserConfig)
 	cacheFilePath := filepath.Join(cachePath, ch)
 
 	// get cached file

--- a/cli/smartling/translate.go
+++ b/cli/smartling/translate.go
@@ -63,20 +63,20 @@ func projectFileHash(projectFilepath string) string {
 	return h[:7] // truncate to 7 chars
 }
 
-func translateProjectFile(projectFilepath, locale, prefix string) (hit bool, b []byte, err error, h string) {
-	filetype := filetypeForProjectFile(projectFilepath)
-	h = projectFileHash(projectFilepath)
+func translateProjectFile(projectFilepath, locale, prefix string) (hit bool, b []byte, err error) {
 
-	cacheFilePath := filepath.Join(cachePath, fmt.Sprintf("%s.%s", h, locale))
+	hash := projectFileHash(projectFilepath)
+
+	cacheFilePath := filepath.Join(cachePath, fmt.Sprintf("%s.%s", hash, locale))
 
 	// check cache
 	hit, b = getCachedTranslations(cacheFilePath)
 	if hit {
-		return hit, b, nil, h
+		return hit, b, nil
 	}
 
 	// translate
-	b, err = translateViaSmartling(projectFilepath, locale, prefix, filetype, ProjectConfig.ParserConfig)
+	b, err = translateViaSmartling(projectFilepath, prefix, locale)
 	if err != nil {
 		return
 	}
@@ -116,7 +116,7 @@ func findIdenticalRemoteFileOrPush(projectFilepath, prefix string) string {
 
 	for _, f := range allRemoteFiles {
 		if f == remoteFile {
-			// file already exists remotely
+			// exact file already exists remotely
 			return f
 		}
 	}
@@ -131,7 +131,7 @@ func findIdenticalRemoteFileOrPush(projectFilepath, prefix string) string {
 	return pushProjectFile(projectFilepath, prefix)
 }
 
-func translateViaSmartling(projectFilepath, locale, prefix string, filetype smartling.FileType, parserConfig map[string]string) (b []byte, err error) {
+func translateViaSmartling(projectFilepath, prefix, locale string) (b []byte, err error) {
 	remotePath := findIdenticalRemoteFileOrPush(projectFilepath, prefix)
 
 	b, err = client.Get(&smartling.GetRequest{

--- a/cli/smartling/translate.go
+++ b/cli/smartling/translate.go
@@ -71,7 +71,7 @@ func translateProjectFile(projectFilepath, locale, prefix string) (hit bool, b [
 	filetype := filetypeForProjectFile(projectFilepath)
 
 	h = hash(localpath, filetype, ProjectConfig.ParserConfig)
-	cacheFilePath := filepath.Join(cachePath, locale, h)
+	cacheFilePath := filepath.Join(cachePath, fmt.Sprintf("%s.%s", h, locale))
 
 	// check cache
 	hit, b = getCachedTranslations(cacheFilePath)

--- a/cli/smartling/translate.go
+++ b/cli/smartling/translate.go
@@ -44,14 +44,8 @@ func (ss stringSlice) contains(s string) bool {
 }
 
 func projectFileHash(projectFilepath string) string {
-	return hash(
-		localRelativeFilePath(projectFilepath),
-		filetypeForProjectFile(projectFilepath),
-		ProjectConfig.ParserConfig,
-	)
-}
+	localpath := localRelativeFilePath(projectFilepath)
 
-func hash(localpath string, filetype smartling.FileType, parserConfig map[string]string) string {
 	file, err := os.Open(localpath)
 	logAndQuitIfError(err)
 	defer file.Close()
@@ -60,7 +54,7 @@ func hash(localpath string, filetype smartling.FileType, parserConfig map[string
 	_, err = io.Copy(hash, file)
 	logAndQuitIfError(err)
 
-	_, err = hash.Write([]byte(fmt.Sprintf("%#v%#v", filetype, parserConfig)))
+	_, err = hash.Write([]byte(fmt.Sprintf("%#v%#v", filetypeForProjectFile(projectFilepath), ProjectConfig.ParserConfig)))
 	logAndQuitIfError(err)
 
 	b := []byte{}
@@ -70,10 +64,9 @@ func hash(localpath string, filetype smartling.FileType, parserConfig map[string
 }
 
 func translateProjectFile(projectFilepath, locale, prefix string) (hit bool, b []byte, err error, h string) {
-	localpath := localRelativeFilePath(projectFilepath)
 	filetype := filetypeForProjectFile(projectFilepath)
+	h = projectFileHash(projectFilepath)
 
-	h = hash(localpath, filetype, ProjectConfig.ParserConfig)
 	cacheFilePath := filepath.Join(cachePath, fmt.Sprintf("%s.%s", h, locale))
 
 	// check cache

--- a/cli/smartling/translate.go
+++ b/cli/smartling/translate.go
@@ -104,8 +104,12 @@ func hash(locale, localpath string, filetype smartling.FileType, parserConfig ma
 	return hex.EncodeToString(hash.Sum(b))
 }
 
-func translate(locale, localpath string, filetype smartling.FileType, parserConfig map[string]string) (hit bool, b []byte, err error, h string) {
-	h = hash(locale, localpath, filetype, parserConfig)
+func translateProjectFile(projectFilepath, locale string) (hit bool, b []byte, err error, h string) {
+
+	localpath := localRelativeFilePath(projectFilepath)
+	filetype := filetypeForProjectFile(projectFilepath)
+
+	h = hash(locale, localpath, filetype, ProjectConfig.ParserConfig)
 	cacheFilePath := filepath.Join(cachePath, h)
 
 	// check cache
@@ -115,7 +119,7 @@ func translate(locale, localpath string, filetype smartling.FileType, parserConf
 	}
 
 	// translate
-	b, err = translateViaSmartling(locale, localpath, filetype, parserConfig)
+	b, err = translateViaSmartling(locale, localpath, filetype, ProjectConfig.ParserConfig)
 	if err != nil {
 		return
 	}

--- a/cli/smartling/translate.go
+++ b/cli/smartling/translate.go
@@ -63,7 +63,9 @@ func hash(localpath string, filetype smartling.FileType, parserConfig map[string
 	logAndQuitIfError(err)
 
 	b := []byte{}
-	return hex.EncodeToString(hash.Sum(b))
+	h := hex.EncodeToString(hash.Sum(b))
+
+	return h[:7] // truncate to 7 chars
 }
 
 func translateProjectFile(projectFilepath, locale, prefix string) (hit bool, b []byte, err error, h string) {

--- a/cli/smartling/translate.go
+++ b/cli/smartling/translate.go
@@ -117,7 +117,7 @@ func translateProjectFile(projectFilepath, locale string) (hit bool, b []byte, e
 	}
 
 	// translate
-	b, err = translateViaSmartling(locale, localpath, filetype, ProjectConfig.ParserConfig)
+	b, err = translateViaSmartling(localpath, locale, filetype, ProjectConfig.ParserConfig)
 	if err != nil {
 		return
 	}
@@ -145,7 +145,7 @@ func getCachedTranslations(cacheFilePath string) (hit bool, b []byte) {
 	return
 }
 
-func translateViaSmartling(locale, localpath string, filetype smartling.FileType, parserConfig map[string]string) (b []byte, err error) {
+func translateViaSmartling(localpath, locale string, filetype smartling.FileType, parserConfig map[string]string) (b []byte, err error) {
 	tmppath, err := uploadAsTempFile(localpath, filetype, parserConfig)
 	if err != nil {
 		return


### PR DESCRIPTION
Changes the remote filename scheme to `/branch/{branch-name|/{hash}/{filename}`

This avoids creating temporary remote files when pulling and checking status.
